### PR TITLE
Add support for a custom menu toggle key

### DIFF
--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -836,6 +836,11 @@ function CreateMenu(info)
         Close = function(t)
             MenuV:CloseMenu(t)
         end,
+        --- Add control key to toggle menu
+        ---@param key int Control key index according to FiveM docs
+        AddControl = function(t, key)
+            MenuV:AddControl(t, key)
+        end,
         --- @see Menu to @see table
         ---@param t Menu
         ---@return table

--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -837,6 +837,7 @@ function CreateMenu(info)
             MenuV:CloseMenu(t)
         end,
         --- Add control key to toggle menu
+        ---@param t Menu
         ---@param key int Control key index according to FiveM docs
         AddControl = function(t, key)
             MenuV:AddControl(t, key)

--- a/menuv.lua
+++ b/menuv.lua
@@ -72,6 +72,8 @@ local menuv_table = {
     Menus = {},
     ---@type Menu[]
     ParentMenus = {},
+    ---@type table<int, string>
+    Controls = {},
     ---@type table<string, function>
     NUICallbacks = {}
 }
@@ -282,6 +284,27 @@ function MenuV:CloseAll(cb)
     cb()
 end
 
+--- Add control key to toggle menu
+---@param menu Menu|string Menu object or UUID
+---@param key int Control key index according to FiveM docs
+function MenuV:AddControl(menu, key)
+    local uuid = Utilities:Typeof(menu) == 'Menu' and menu.UUID or Utilities:Typeof(menu) == 'string' and menu
+
+    if (uuid == nil) then return end
+
+    self.Controls[key] = uuid
+end
+
+--- Remove menu toggle key
+---@param key int Control key index according to FiveM docs
+function MenuV:RemoveControl(key)
+    local uuid = Utilities:Typeof(menu) == 'Menu' and menu.UUID or Utilities:Typeof(menu) == 'string' and menu
+
+    if (uuid == nil) then return end
+
+    self.Controls[key] = nil
+end
+
 --- Mark MenuV as loaded when `main` resource is loaded
 exports['menuv']:IsLoaded(function()
     MenuV.Loaded = true
@@ -457,6 +480,21 @@ REGISTER_NUI_CALLBACK('update', function(info, cb)
                 end
             end
             return
+        end
+    end
+end)
+
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(0)
+        for k, v in pairs(MenuV.Controls) do
+            if IsControlJustPressed(0, k) then
+                if MenuV.CurrentMenu ~= nil then
+                    MenuV:CloseAll()
+                else
+                    MenuV:OpenMenu(v)
+                end
+            end
         end
     end
 end)


### PR DESCRIPTION
This adds support for the methods:

```
MenuV:AddControl(menu, key)
MenuV:RemoveControl(menu, key)
<MenuObject>:AddControl(key)
```

Adding a control key will add a key to toggle a certain menu. Removing a key will, as you may expect, remove it.

Upon hitting a control key, if no menu is open, it will open the menu that corresponds to the key pressed. If a menu is open at the time the key is pressed, it will close all menus.