### PR TITLE
Add the ability to create child menus

### DIFF
--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -799,9 +799,10 @@ function CreateMenu(info)
         end,
         --- Create child menu from properties of this object
         ---@param t Menu|string MenuV menu
+        ---@param namespace string Namespace of menu
         ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
-        InheritMenu = function(t, overrides)
-            return MenuV:InheritMenu(t, overrides)
+        InheritMenu = function(t, namespace, overrides)
+            return MenuV:InheritMenu(t, namespace, overrides)
         end,
         --- Add control key for specific menu
         ---@param t Menu|string MenuV menu

--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -797,6 +797,12 @@ function CreateMenu(info)
 
             return t.Items[#t.Items] or item
         end,
+        --- Create child menu from properties of this object
+        ---@param t Menu|string MenuV menu
+        ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
+        CreateChildMenu = function(t, overrides)
+            return MenuV:CreateChildMenu(t, overrides)
+        end,
         --- Add control key for specific menu
         ---@param t Menu|string MenuV menu
         ---@param action string Name of action

--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -800,8 +800,8 @@ function CreateMenu(info)
         --- Create child menu from properties of this object
         ---@param t Menu|string MenuV menu
         ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
-        CreateChildMenu = function(t, overrides)
-            return MenuV:CreateChildMenu(t, overrides)
+        InheritMenu = function(t, overrides)
+            return MenuV:InheritMenu(t, overrides)
         end,
         --- Add control key for specific menu
         ---@param t Menu|string MenuV menu

--- a/menuv.lua
+++ b/menuv.lua
@@ -187,7 +187,7 @@ end
 --- Create a menu that inherits properties from another menu
 ---@param parent Menu|string Menu or UUID of menu
 ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
-function MenuV:CreateChildMenu(parent, overrides)
+function MenuV:InheritMenu(parent, overrides)
     overrides = Utilities:Ensure(overrides, {})
 
     local uuid = Utilities:Typeof(parent) == 'Menu' and parent.UUID or Utilities:Typeof(parent) == 'string' and parent

--- a/menuv.lua
+++ b/menuv.lua
@@ -184,6 +184,40 @@ function MenuV:CreateMenu(title, subtitle, position, r, g, b, size, texture, dic
     return self.Menus[index] or menu
 end
 
+--- Create a menu that inherits properties from another menu
+---@param parent Menu|string Menu or UUID of menu
+---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
+function MenuV:CreateChildMenu(parent, overrides)
+    overrides = Utilities:Ensure(overrides, {})
+
+    local uuid = Utilities:Typeof(parent) == 'Menu' and parent.UUID or Utilities:Typeof(parent) == 'string' and parent
+
+    if (uuid == nil) then return end
+
+    parentMenu = self:GetMenu(uuid)
+
+    if (parentMenu == nil) then return end
+
+    local menu = CreateMenu({
+        Title = Utilities:Ensure(overrides.title or overrides.Title, parentMenu.Title),
+        Subtitle = Utilities:Ensure(overrides.subtitle or overrides.Subtitle, parentMenu.Subtitle),
+        Position = Utilities:Ensure(overrides.position or overrides.Position, parentMenu.Position),
+        R = Utilities:Ensure(overrides.r or overrides.R, parentMenu.Color.R),
+        G = Utilities:Ensure(overrides.g or overrides.G, parentMenu.Color.G),
+        B = Utilities:Ensure(overrides.b or overrides.B, parentMenu.Color.B),
+        Size = Utilities:Ensure(overrides.size or overrides.Size, parentMenu.Size),
+        Texture = Utilities:Ensure(overrides.texture or overrides.Texture, parentMenu.Texture),
+        Dictionary = Utilities:Ensure(overrides.dictionary or overrides.Dictionary, parentMenu.Dictionary),
+        Namespace = Utilities:Ensure(overrides.namespace or overrides.Namespace, parentMenu.Namespace)
+    })
+
+    local index = #(self.Menus or {}) + 1
+
+    insert(self.Menus, index, menu)
+
+    return self.Menus[index] or menu
+end
+
 --- Load a menu based on `uuid`
 ---@param uuid string UUID of menu
 ---@return Menu|nil Founded menu or `nil`

--- a/menuv.lua
+++ b/menuv.lua
@@ -186,8 +186,9 @@ end
 
 --- Create a menu that inherits properties from another menu
 ---@param parent Menu|string Menu or UUID of menu
+---@param namespace string Namespace of menu
 ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
-function MenuV:InheritMenu(parent, overrides)
+function MenuV:InheritMenu(parent, namespace, overrides)
     overrides = Utilities:Ensure(overrides, {})
 
     local uuid = Utilities:Typeof(parent) == 'Menu' and parent.UUID or Utilities:Typeof(parent) == 'string' and parent
@@ -208,7 +209,7 @@ function MenuV:InheritMenu(parent, overrides)
         Size = Utilities:Ensure(overrides.size or overrides.Size, parentMenu.Size),
         Texture = Utilities:Ensure(overrides.texture or overrides.Texture, parentMenu.Texture),
         Dictionary = Utilities:Ensure(overrides.dictionary or overrides.Dictionary, parentMenu.Dictionary),
-        Namespace = Utilities:Ensure(overrides.namespace or overrides.Namespace, parentMenu.Namespace)
+        Namespace = namespace
     })
 
     local index = #(self.Menus or {}) + 1

--- a/menuv.lua
+++ b/menuv.lua
@@ -194,7 +194,7 @@ function MenuV:CreateChildMenu(parent, overrides)
 
     if (uuid == nil) then return end
 
-    parentMenu = self:GetMenu(uuid)
+    local parentMenu = self:GetMenu(uuid)
 
     if (parentMenu == nil) then return end
 


### PR DESCRIPTION
I'm back with another PR!

This adds the ability to create a child menu; a menu that inherits properties (such as title, subtitle, color, etc.) from the parent menu. It also allows for overrides to be made if you have a few properties that you need to be different from that of the parent.

This is useful if you are creating a certain style of menu, and would like the design to stay persistent throughout all submenus.
Example:
```lua
local baseMenu = MenuV:CreateMenu(false, 'Parent Menu', 'topright', 255, 0, 0, 'size-200', 'my-dict', 'my-texture', 'examplenamespace') -- create a parent menu for the child to inherit from
local childMenu = baseMenu:CreateChildMenu({subtitle='Child Menu'}) -- create the child menu that inherits all properties from the parent menu, except for the subtitle
```

Methods Added:
```lua
MenuV:CreateChildMenu(menu: Menu|string, overrides: table<string, string|number>)
<Menu>:CreateChildMenu(overrides: table<string|number>)
```