### PR TITLE
Change position of namespace argument in InheritMenu() methods

### DIFF
--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -801,8 +801,8 @@ function CreateMenu(info)
         ---@param t Menu|string MenuV menu
         ---@param namespace string Namespace of menu
         ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
-        InheritMenu = function(t, namespace, overrides)
-            return MenuV:InheritMenu(t, namespace, overrides)
+        InheritMenu = function(t, overrides, namespace)
+            return MenuV:InheritMenu(t, overrides, namespace)
         end,
         --- Add control key for specific menu
         ---@param t Menu|string MenuV menu

--- a/menuv.lua
+++ b/menuv.lua
@@ -188,7 +188,7 @@ end
 ---@param parent Menu|string Menu or UUID of menu
 ---@param namespace string Namespace of menu
 ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
-function MenuV:InheritMenu(parent, namespace, overrides)
+function MenuV:InheritMenu(parent, overrides, namespace)
     overrides = Utilities:Ensure(overrides, {})
 
     local uuid = Utilities:Typeof(parent) == 'Menu' and parent.UUID or Utilities:Typeof(parent) == 'string' and parent


### PR DESCRIPTION
Sorry for not doing this in the previous pull request, but I just thought of this.

Not every menu needs a namespace, since not every menu needs a keybind. This would allow people to omit the namespace argument as needed.