### PR TITLE
One more thing!

### DIFF
--- a/app/lua_components/menu.lua
+++ b/app/lua_components/menu.lua
@@ -806,10 +806,10 @@ function CreateMenu(info)
         end,
         --- Create child menu from properties of this object
         ---@param t Menu|string MenuV menu
-        ---@param namespace string Namespace of menu
         ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
+        ---@param namespace string Namespace of menu
         InheritMenu = function(t, overrides, namespace)
-            return MenuV:InheritMenu(t, namespace, overrides)
+            return MenuV:InheritMenu(t, overrides, namespace)
         end,
         --- Add control key for specific menu
         ---@param t Menu|string MenuV menu

--- a/menuv.lua
+++ b/menuv.lua
@@ -187,8 +187,8 @@ end
 
 --- Create a menu that inherits properties from another menu
 ---@param parent Menu|string Menu or UUID of menu
----@param namespace string Namespace of menu
 ---@param overrides table<string, string|number> Properties to override in menu object (ignore parent)
+---@param namespace string Namespace of menu
 function MenuV:InheritMenu(parent, overrides, namespace)
     overrides = Utilities:Ensure(overrides, {})
 


### PR DESCRIPTION
I think GitHub messed up and/or had a conflict because line 812 in app/lua_components/menu.lua was somehow not updated when PR #7 was merged.

This also fixes the position of doc comments in the `InheritMenu()` methods (just for aesthetic purposes).