### PR TITLE
Fix(Close All): Propagate 'close' event for parent menus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,9 @@ dist
 !.vscode/extensions.json
 *.code-workspace
 
+### IntelliJ ###
+.idea
+
 ### Vue ###
 # gitignore template for Vue.js projects
 #

--- a/source/menuv.lua
+++ b/source/menuv.lua
@@ -542,12 +542,23 @@ REGISTER_NUI_CALLBACK('close', function(info, cb)
 end)
 
 REGISTER_NUI_CALLBACK('close_all', function(info, cb)
-    if (MenuV.CurrentMenu == nil) then cb('ok') return end
+    if (MenuV.CurrentMenu == nil) then
+        for _, parentMenu in ipairs(MenuV.ParentMenus) do
+            parentMenu:Trigger('close')
+        end
+        MenuV.ParentMenus = {}
+
+        cb('ok')
+        return
+    end
 
     MenuV.CurrentMenu:RemoveOnEvent('update', MenuV.CurrentUpdateUUID)
     MenuV.CurrentMenu:Trigger('close')
     MenuV.CurrentMenu:DestroyThreads()
     MenuV.CurrentMenu = nil
+    for _, parentMenu in ipairs(MenuV.ParentMenus) do
+        parentMenu:Trigger('close')
+    end
     MenuV.ParentMenus = {}
 
     cb('ok')


### PR DESCRIPTION
When you're using MenuV with nested menus the close_all action doesn't trigger back to the parent menus. This is problematic when you're using the `close` event on the top menu handling a camera and when calling the close_all callback within multiple nested menus, the top menu doesn't clear the camera.

We did the modification on a fork of this repository so we're sharing the fix for the community. I've put the liberty to clean the parent menus after looping it, feel free to remove this line if necessary.